### PR TITLE
Fix package footer

### DIFF
--- a/wwtime.el
+++ b/wwtime.el
@@ -459,4 +459,4 @@ alternate time zone"
 
 (provide 'wwtime)
 
-;; wwtime.el ends here
+;;; wwtime.el ends here


### PR DESCRIPTION
Footer requires three semicolons, not two.
